### PR TITLE
Правки surf_mvp_module

### DIFF
--- a/surf_mvp_module/Code/Presenter/module_input.swift.liquid
+++ b/surf_mvp_module/Code/Presenter/module_input.swift.liquid
@@ -7,4 +7,5 @@
 //
 
 protocol {{ module_info.name }}ModuleInput: class {
+
 }

--- a/surf_mvp_module/Code/Presenter/module_output.swift.liquid
+++ b/surf_mvp_module/Code/Presenter/module_output.swift.liquid
@@ -7,4 +7,5 @@
 //
 
 protocol {{ module_info.name }}ModuleOutput: class {
+
 }

--- a/surf_mvp_module/Code/Presenter/presenter.swift.liquid
+++ b/surf_mvp_module/Code/Presenter/presenter.swift.liquid
@@ -16,10 +16,6 @@ final class {{ module_info.name }}Presenter: {{ module_info.name }}ViewOutput, {
 
     // MARK: - {{ module_info.name }}ViewOutput
 
-    func viewLoaded() {
-        view?.setupInitialState()
-    }
-
     // MARK: - {{ module_info.name }}ModuleInput
 
 }

--- a/surf_mvp_module/Code/View/view_controller.swift.liquid
+++ b/surf_mvp_module/Code/View/view_controller.swift.liquid
@@ -18,13 +18,8 @@ final class {{ module_info.name }}ViewController: UIViewController, {{ module_in
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        output?.viewLoaded()
     }
 
     // MARK: - {{ module_info.name }}ViewInput
-
-    func setupInitialState() {
-
-    }
 
 }

--- a/surf_mvp_module/Code/View/view_input.swift.liquid
+++ b/surf_mvp_module/Code/View/view_input.swift.liquid
@@ -7,6 +7,5 @@
 //
 
 protocol {{ module_info.name }}ViewInput: class {
-    /// Method for setup initial state of view
-    func setupInitialState()
+
 }

--- a/surf_mvp_module/Code/View/view_output.swift.liquid
+++ b/surf_mvp_module/Code/View/view_output.swift.liquid
@@ -7,6 +7,5 @@
 //
 
 protocol {{ module_info.name }}ViewOutput {
-    /// Notify presenter that view is ready
-    func viewLoaded()
+
 }

--- a/surf_mvp_module/Tests/Presenter/presenter_tests.swift.liquid
+++ b/surf_mvp_module/Tests/Presenter/presenter_tests.swift.liquid
@@ -37,28 +37,15 @@ final class {{ module_info.name }}PresenterTest: XCTestCase {
 
     // MARK: - Main tests
 
-    func testThatPresenterHandlesViewLoadedEvent() {
-        // when 
-        presenter?.viewLoaded()
-        // then
-        XCTAssertTrue((presenter?.view as? MockViewController)?.setupInitialStateWasCalled == true)
-    }
-
     // MARK: - Mocks
 
     private final class MockRouter: {{ module_info.name }}RouterInput {
     }
 
     private final class MockViewController: {{ module_info.name }}ViewInput {
-        var setupInitialStateWasCalled: Bool = false
-
-        func setupInitialState() {
-            setupInitialStateWasCalled = true
-        }
     }
 
     private final class MockModuleOutput: {{ module_info.name }}ModuleOutput {
-
     }
 
 }

--- a/surf_mvp_module/Tests/Router/router_tests.swift.liquid
+++ b/surf_mvp_module/Tests/Router/router_tests.swift.liquid
@@ -11,15 +11,50 @@ import XCTest
 
 final class {{ module_info.name }}RouterTests: XCTestCase {
 
-	// MARK: - XCTestCase
+	// MARK: - Properties
+
+    private var view: MockModuleTransitionable?
+    private var router: {{ module_info.name }}Router?
+
+    // MARK: - XCTestCase
 
     override func setUp() {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        router = {{ module_info.name }}Router()
+        view = MockModuleTransitionable()
+        router?.view = view
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
+        view = nil
+        router = nil
     }
+
+    // MARK: - Main tests
+
+    // MARK: - Mocks
+
+    private final class MockModuleTransitionable: ModuleTransitionable {
+
+        func showModule(_ module: UIViewController) {
+        }
+
+        func dismissView(animated: Bool, completion: (() -> Void)?) {
+        }
+
+        func presentModule(_ module: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        }
+
+        func pop(animated: Bool) {
+        }
+
+        func push(module: UIViewController, animated: Bool) {
+        }
+
+        func push(module: UIViewController, animated: Bool, hideTabBar: Bool) {
+        }
+
+    }
+
 }

--- a/surf_mvp_module/Tests/View/view_tests.swift.liquid
+++ b/surf_mvp_module/Tests/View/view_tests.swift.liquid
@@ -33,21 +33,9 @@ final class {{ module_info.name }}ViewTests: XCTestCase {
 
     // MARK: - Main tests
 
-    func testThatViewNotifiesPresenterOnDidLoad() {
-        // when
-        self.view?.viewDidLoad()
-        // then
-        XCTAssert(self.output?.viewLoadedWasCalled == true)
-    }
-
     // MARK: - Mocks
 
-    final class {{ module_info.name }}ViewOutputMock: {{ module_info.name }}ViewOutput {
-        var viewLoadedWasCalled: Bool = false
-
-        func viewLoaded() {
-            viewLoadedWasCalled = true
-        }
+    private final class {{ module_info.name }}ViewOutputMock: {{ module_info.name }}ViewOutput {
     }
 
 }


### PR DESCRIPTION
**Что сделано:**
- Удалил `setupInitialState()` из **ViewInput**
- Удалил `viewLoaded()` из **ViewOutput**
- Добавил мокирование в **RouterTests**

**Предложения:**
- Есть идея просто написать большой мок для **ModuleTransitionable** и не генерить каждый раз
- Можно сделать генерацию файла `{{ module_info.name }}ViewState` и метод для **ViewInput** `configure(with state:)`, но не уверен, что это нужно для всех проектов и даже для проектов, где используется подход со стейтами, так как бывают экраны с статичными данными в один стейт
